### PR TITLE
Add API for Retrieving Discord <-> Group Mapping

### DIFF
--- a/src/Http/Controllers/Api/v1/DiscordApiController.php
+++ b/src/Http/Controllers/Api/v1/DiscordApiController.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * This file is part of discord-connector and provides user synchronization between both SeAT and a Discord Guild
+ *
+ * Copyright (C) 2016, 2017, 2018  Loïc Leuilliot <loic.leuilliot@gmail.com>
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Warlof\Seat\Connector\Discord\Http\Controllers\Api\v1;
+
+
+use Seat\Api\Http\Controllers\Api\v2\ApiController;
+use Warlof\Seat\Connector\Discord\Models\DiscordUser;
+
+/**
+ * Class DiscordApiController
+ * @package Warlof\Seat\Connector\Discord\Http\Controllers\Api\v1
+ */
+class DiscordApiController extends ApiController
+{
+    /**
+     * SWG\Get(
+     *     path="/mappings",
+     *     tags={"discord-connector"},
+     *     summary="Get a list of users, group id, and discord nickname",
+     *     description="Returns list of users along with their discord mapping",
+     *     security={"ApiKeyAuth"},
+     *     @SWG\Response(response=200, description="Successful operation"),
+     *     @SWG\Response(response=400, description="Bad request"),
+     *     @SWG\Response(response=401, description="Unauthorized"),
+     *    )
+     * 
+     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     */
+    public function getDiscordMappings()
+    {
+        $discord_users = DiscordUser::all();
+        return response()->json($discord_users->map(
+            function($item){
+                return [
+                    'group_id' => $item->group_id,
+                    'discord_id' => $item->discord_id,
+                    'nick' => $item->nick
+                ];
+            })
+        );
+    }
+}
+?>

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -19,6 +19,18 @@
  */
 
 Route::group([
+    'namespace' => 'Warlof\Seat\Connector\Discord\Http\Controllers\Api\v1',
+    'prefix' => 'discord-connector',
+    'middleware' => 'api.auth'
+], function() {
+    Route::group(['prefix' => 'api'], function () {
+        Route::group(['prefix' => 'v1'], function () {
+                Route::get('/mapping', 'DiscordApiController@getDiscordMappings');
+        });
+    });
+});
+
+Route::group([
     'namespace' => 'Warlof\Seat\Connector\Discord\Http\Controllers',
     'prefix' => 'discord-connector'
 ], function() {


### PR DESCRIPTION
This PR adds a new API that works with SeAT's API. This will allow our Discord Bot to interact with SeAT and this connector :) 

New API Route: `/discord-connector/api/v1/mapping`
Example Response: 

```
[
    {
        "group_id": 1,
        "discord_id": <snowflake_id>,
        "nick": "White Aero"
    }
]
```
