### PR TITLE
Better response towards invalid refresh token

### DIFF
--- a/src/Helpers/Helper.php
+++ b/src/Helpers/Helper.php
@@ -99,6 +99,11 @@ class Helper
         if (empty($enabled_character_ids))
             return $channels;
 
+        $strict_mode = setting('warlof.discord-cqonnector.strict', true);
+        $all_token_valid = sizeof($enabled_character_ids) == $discord_user->group->users->count();
+        if ($strict_mode && ! $all_token_valid) 
+            return $channels;
+
         $rows = Group::join('warlof_discord_connector_role_groups', 'warlof_discord_connector_role_groups.group_id', '=', 'groups.id')
                     ->select('discord_role_id')
                     ->where('groups.id', $discord_user->group_id)

--- a/src/Http/Controllers/Services/OAuthController.php
+++ b/src/Http/Controllers/Services/OAuthController.php
@@ -69,6 +69,8 @@ class OAuthController extends Controller
         ]]);
 
         setting(['warlof.discord-connector.ticker', $request->input('discord-configuration-ticker')], true);
+        setting(['warlof.discord-connector.nickfmt', $request->input('discord-configuration-nick-format')], true);
+        setting(['warlof.discord-connector.strict', $request->input('discord-configuration-strict-security')], true);
 
         return redirect($this->oAuthAuthorization($request->input('discord-configuration-client'), $state));
     }

--- a/src/Jobs/Invite.php
+++ b/src/Jobs/Invite.php
@@ -97,7 +97,8 @@ class Invite extends DiscordJobBase
 
         if (setting('warlof.discord-connector.ticker', true)) {
             $corporation = CorporationInfo::findOrFail($this->discord_user->group->main_character->corporation_id);
-            $expected_nickname = sprintf('[%s] %s', $corporation->ticker, $nickname);
+            $nickfmt = setting('warlof.discord-connector.nickfmt', true) ?: '[%s] %s';
+            $expected_nickname = sprintf($nickfmt, $corporation->ticker, $nickname);
         }
 
         $expected_nickname = Str::limit($expected_nickname, Helper::NICKNAME_LENGTH_LIMIT, '');

--- a/src/resources/views/configuration.blade.php
+++ b/src/resources/views/configuration.blade.php
@@ -96,6 +96,26 @@
                             </div>
                         </div>
                     </div>
+
+                    <div class="form-group">
+                        <label for="discord-configuration-nick-format" class="col-md-4">Nickname Format</label>
+                        <div class="col-md-7">
+                            <div class="input-group input-group-sm">
+                                <input type="input" id="discord-configuration-nick-format"
+                                       name="discord-configuration-nick-format" value="{{ setting('warlof.discord-connector.nickfmt', true) ?: '[%s] %s' }}" />
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="discord-configuration-strict-security" class="col-md-4">Strict Security</label>
+                        <div class="col-md-7">
+                            <div class="input-group input-group-sm">
+                                <input type="checkbox" id="discord-configuration-strict-security"
+                                       name="discord-configuration-strict-security" @if(setting('warlof.discord-connector.strict', true)) checked="checked" @endif />
+                            </div>
+                        </div>
+                    </div>
                 </div>
 
                 <div class="box-footer">


### PR DESCRIPTION
People create and dispose one-time characters, so it is not a good idea to deny all discord permission for only one expired refresh token. Here I only get valid tokens for a user(group), and use these characters to calculate permissions.