### PR TITLE
Fix setting nickname to null when no nick update required

### DIFF
--- a/src/Jobs/MemberOrchestrator.php
+++ b/src/Jobs/MemberOrchestrator.php
@@ -210,7 +210,7 @@ class MemberOrchestrator extends DiscordJobBase
         // apply changes to the guild member
         if ($is_roles_outdated || ! is_null($new_nickname)) {
             $this->updateMemberRoles($member, $is_roles_outdated ? $roles : null, $new_nickname);
-            $discord_user->nick = $new_nickname;
+            $discord_user->nick = $new_nickname ? $new_nickname : $discord_user->nick;
             $discord_user->save();
             DiscordLog::create([
                 'event' => 'sync',


### PR DESCRIPTION
When running the sync process and no nickname update was required, MemberOrchestrator would attempt to update the nick property on discord_user to null, causing a SQL error.

Example: 

```[2019-07-18 23:15:51] local.ERROR: SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'nick' cannot be null (SQL: update `warlof_discord_connector_users` set `nick` = , `updated_at` = 2019-07-18 23:15:51 where `group_id` = 18)```