### PR TITLE
enhance: remove email scope requirement, use username+discriminator instead

### DIFF
--- a/src/Config/seat-connector.config.php
+++ b/src/Config/seat-connector.config.php
@@ -39,5 +39,10 @@ return [
             'label' => 'seat-connector-discord::seat.bot_token',
             'type'  => 'text',
         ],
+        [
+            'name'  => 'use_email_scope',
+            'label' => 'seat-connector-discord::seat.use_email_scope',
+            'type'  => 'checkbox',
+        ],
     ],
 ];

--- a/src/Http/Controllers/RegistrationController.php
+++ b/src/Http/Controllers/RegistrationController.php
@@ -41,7 +41,7 @@ use Warlof\Seat\Connector\Models\User;
 class RegistrationController extends Controller
 {
     const SCOPES = [
-        'identify', 'email', 'guilds.join',
+        'identify', 'guilds.join',
     ];
 
     /**
@@ -89,11 +89,6 @@ class RegistrationController extends Controller
         // retrieve authenticated user
         $socialite_user = Socialite::driver('discord')->setConfig($config)->user();
 
-        // ensure email is properly set on the account - it's our UID
-        if (empty($socialite_user->email))
-            return redirect()->to('seat-connector.identities')
-                ->with('error', 'Sorry, but it seems your Discord account does not have any e-mail address setup yet.');
-
         // update or create the connector user
         $original_user = User::where('connector_type', 'discord')->where('user_id', auth()->user()->id)->first();
 
@@ -107,7 +102,7 @@ class RegistrationController extends Controller
             'user_id'        => auth()->user()->id,
         ], [
             'connector_id'   => $socialite_user->id,
-            'unique_id'      => $socialite_user->email,
+            'unique_id'      => $socialite_user->name . '#' . $socialite_user->user['discriminator'],
             'connector_name' => $socialite_user->nickname,
         ]);
 

--- a/src/Http/Controllers/SettingsController.php
+++ b/src/Http/Controllers/SettingsController.php
@@ -55,15 +55,17 @@ class SettingsController extends Controller
     public function store(Request $request)
     {
         $request->validate([
-            'client_id'     => 'required|string',
-            'client_secret' => 'required|string',
-            'bot_token'     => 'required|string',
+            'client_id'       => 'required|string',
+            'client_secret'   => 'required|string',
+            'bot_token'       => 'required|string',
+            'use_email_scope' => 'boolean',
         ]);
 
         $settings = (object) [
-            'client_id'     => $request->input('client_id'),
-            'client_secret' => $request->input('client_secret'),
-            'bot_token'     => $request->input('bot_token'),
+            'client_id'       => $request->input('client_id'),
+            'client_secret'   => $request->input('client_secret'),
+            'bot_token'       => $request->input('bot_token'),
+            'use_email_scope' => $request->input('use_email_scope', 0),
         ];
 
         setting(['seat-connector.drivers.discord', $settings], true);

--- a/src/lang/en/seat.php
+++ b/src/lang/en/seat.php
@@ -1,7 +1,8 @@
 <?php
 
 return [
-    'client_id'     => 'Client ID',
-    'client_secret' => 'Client Secret',
-    'bot_token'     => 'Bot Token',
+    'client_id'       => 'Client ID',
+    'client_secret'   => 'Client Secret',
+    'bot_token'       => 'Bot Token',
+    'use_email_scope' => 'Use email as Unique ID? Email scope will be requested from users.',
 ];


### PR DESCRIPTION
This PR removes the email scope requirement for this driver, instead using the users Discord username with the discriminator as the unique ID. 

Given how easy it is to change usernames and emails on Discord, and that verification isn't required in most cases, the use of the username/discriminator instead should achieve the same outcome but not irk users as much about potentially giving out their Discord email ID's. 

Relies on warlof/seat-connector#54 to provide support for checkbox inputs as part of the drivers settings.