### PR TITLE
Update composer.json for Seat v5 requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "ext-json": "*",
         "warlof/seat-connector": "^2.0",
-        "socialiteproviders/discord": "^v2.0"
+        "socialiteproviders/discord": "^v4.2"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0"


### PR DESCRIPTION
Bumped version of `socialiteproviders/discord` to be compatible with PHP 8.x, now required for Seat.